### PR TITLE
Implementing goroutines for parsing each news resource in news-aggregator

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -14,56 +14,54 @@ type Parser interface {
 	ParseFile(f *os.File) ([]model.Article, error)
 }
 
-func ParseArticlesFromFiles(files []string) ([]model.Article, error) {
+func ParseArticlesFromFile(file string) ([]model.Article, error) {
 	var parsedArticles []model.Article
 	var parser Parser
-	for _, filePath := range files {
-		file, err := os.Open(filePath)
+	f, err := os.Open(file)
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+		return nil, err
+	}
+
+	defer func(file *os.File) {
+		err := file.Close()
 		if err != nil {
-			fmt.Println("Error opening file:", err)
-			continue
+			panic(err)
 		}
+	}(f)
 
-		defer func(file *os.File) {
-			err := file.Close()
-			if err != nil {
-				panic(err)
-			}
-		}(file)
+	format := DetermineFileFormat(file)
 
-		format := DetermineFileFormat(filePath)
-
-		switch format {
-		case "rss":
-			parser = &rss.Parser{}
-		case "json":
-			parser = &json.Parser{}
-		case "html":
-			config := html.FeedConfig{
-				ArticleSelector:     "a.gnt_m_flm_a",
-				LinkSelector:        "",
-				DescriptionSelector: "data-c-br",
-				PubDateSelector:     "div.gnt_m_flm_sbt",
-				Source:              "USA TODAY",
-				DateAttribute:       "data-c-dt",
-				TimeFormat: []string{
-					"2006-01-02 15:04",
-					"Jan 02, 2006",
-				},
-			}
-			parser = html.NewHtmlParser(config)
-		default:
-			fmt.Println("Unsupported file format:", filePath)
-			continue
+	switch format {
+	case "rss":
+		parser = &rss.Parser{}
+	case "json":
+		parser = &json.Parser{}
+	case "html":
+		config := html.FeedConfig{
+			ArticleSelector:     "a.gnt_m_flm_a",
+			LinkSelector:        "",
+			DescriptionSelector: "data-c-br",
+			PubDateSelector:     "div.gnt_m_flm_sbt",
+			Source:              "USA TODAY",
+			DateAttribute:       "data-c-dt",
+			TimeFormat: []string{
+				"2006-01-02 15:04",
+				"Jan 02, 2006",
+			},
 		}
+		parser = html.NewHtmlParser(config)
+	default:
+		fmt.Println("Unsupported file format:")
+		return nil, err
+	}
 
-		articles, err := parser.ParseFile(file)
+	articles, err := parser.ParseFile(f)
+	if err != nil {
+		fmt.Println("Error parsing file with", format, "parser:", err)
+		return nil, err
+	} else {
 		parsedArticles = append(parsedArticles, articles...)
-		if err != nil {
-			fmt.Println("Error parsing file with", format, "parser:", err)
-			continue
-		}
-
 	}
 
 	return parsedArticles, nil

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -68,7 +68,7 @@ func TestParseArticlesFromFiles(t *testing.T) {
 					PubDate:     time.Date(2006, time.January, 3, 15, 4, 5, 0, time.UTC),
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "all invalid files",
@@ -76,7 +76,7 @@ func TestParseArticlesFromFiles(t *testing.T) {
 				files: []string{"testdata/invalid_rss.xml", "testdata/invalid.json"},
 			},
 			want:    nil,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "empty files",
@@ -90,13 +90,22 @@ func TestParseArticlesFromFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := require.New(t)
-			got, err := ParseArticlesFromFiles(tt.args.files)
-			if tt.wantErr {
-				assert.Error(err, "ParseArticlesFromFiles() should return an error")
-			} else {
-				assert.NoError(err, "ParseArticlesFromFiles() should not return an error")
+			var got []model.Article
+			var err error
+			for _, file := range tt.args.files {
+				articles, e := ParseArticlesFromFile(file)
+				if e != nil {
+					err = e
+				} else {
+					got = append(got, articles...)
+				}
 			}
-			assert.Equal(tt.want, got, "ParseArticlesFromFiles() returned unexpected result")
+			if tt.wantErr {
+				assert.Error(err, "ParseArticlesFromFile() should return an error")
+			} else {
+				assert.NoError(err, "ParseArticlesFromFile() should not return an error")
+			}
+			assert.Equal(tt.want, got, "ParseArticlesFromFile() returned unexpected result")
 		})
 	}
 }


### PR DESCRIPTION
### Pull Request Description: Go routines for CLI News Aggregator

#### Overview
This pull request provides an implementation for parsing each source in separate go-routine



#### Purpose
Each news source should be parsed in a separate go-routine. The refactored code should be more scalable and can handle larger datasets more efficiently.

### Solution

Change ParseFiles() structure to ParseFile(), for the ability to run each file in its go-routine. Add channel-based communication for results and errors. 

#### Next Steps
- Wait for review 😊


